### PR TITLE
Faster Lost Lace

### DIFF
--- a/FSMEdits/FasterBossAndNPC.cs
+++ b/FSMEdits/FasterBossAndNPC.cs
@@ -1,3 +1,6 @@
+using HutongGames.PlayMaker;
+using HutongGames.PlayMaker.Actions;
+
 namespace QoL.FSMEdits;
 
 internal static class FasterBossAndNpc
@@ -11,6 +14,26 @@ internal static class FasterBossAndNpc
             return;
 
         fsm.ChangeTransition("Encountered?", "MEET", "Refight");
+    }
+
+    internal static void FasterLostLace(PlayMakerFSM fsm) {
+        if (!Configs.FasterBossLoad.Value)
+            return;
+
+        if (fsm is not { FsmName: "Control", gameObject: { name: "Intro Control", scene.name: "Abyss_Cocoon" } })
+            return;
+
+        fsm.ChangeTransition("Check Encountered", FsmEvent.Finished.Name, "ENCOUNTERED");
+        
+        FsmState stateEmerge = fsm.GetState("Lace Re-emerge")!;
+        const float SPEED_MULT = 3f;
+        stateEmerge.GetAction<ActivateGameObject>(10)!
+            .gameObject.GameObject.Value.GetComponent<Animator>()
+            .speed = SPEED_MULT;
+        stateEmerge.GetAction<Wait>(11)!.time.Value /= SPEED_MULT;
+
+        fsm.DisableAction("Lace Roar", 4); // Wait
+        fsm.DisableAction("Silk Scream", 1); // Wait
     }
 
     internal static void FasterNPC(PlayMakerFSM fsm)

--- a/Patches/PlayMakerFSMPatch.cs
+++ b/Patches/PlayMakerFSMPatch.cs
@@ -10,6 +10,7 @@ internal static class PlayMakerFSMPatch
     private static readonly Action<PlayMakerFSM>[] edits =
     [
         FasterBossAndNpc.FasterLace1,
+        FasterBossAndNpc.FasterLostLace,
         FasterBossAndNpc.FasterNPC,
         Bellway.BellBeast,
         Bellway.Toll,


### PR DESCRIPTION
The roar part has some problem: the scream audio lingers to after the fight has begun, which might cause interference. We can either:
- Speeds up the scream, faster, but with more code and may sound weird
- Don't disable the second wait, slower but simpler